### PR TITLE
Bump excon dependency

### DIFF
--- a/jeff.gemspec
+++ b/jeff.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Jeff::VERSION
 
-  gem.add_dependency 'excon', '~> 0.23.0'
+  gem.add_dependency 'excon', '~> 0.25.0'
 
   gem.required_ruby_version = '>= 1.9'
 end


### PR DESCRIPTION
Was trying to use this together with Fog 1.14.0 which has a dependency on Excon ~> 0.25.0.
