### PR TITLE
Make POST action use body as default instead of query string

### DIFF
--- a/lib/jeff.rb
+++ b/lib/jeff.rb
@@ -135,14 +135,10 @@ module Jeff
         options.store(:method, :#{method})
         add_md5_digest options
         sign options
-
-        begin
-          connection.request(options)
-        rescue Excon::Errors::RequestURITooLong
-          raise if options[:body] || options[:method] != :post
+        if !options[:body] and options[:method] == :post
           move_query_to_body options
-          retry
         end
+        connection.request(options)
       end
     DEF
   end


### PR DESCRIPTION
I have run into a problem recently creating large create_inbound_shipment_plan requests. When adding more than around 30 skus, I get a 400 Excon::Errors::BadRequest back from Amazon with no error message. Since I am not getting a 414 Excon::Errors::RequestURITooLong back, it isn't hitting the rescue case and retrying. As far as I can tell, this is only happening to me when the query string gets too long.

I decided that instead to be safer, I would make the POST with body action default when possible, instead of performing a retry after attempting to use the query string. I would be open to any improvements or suggestions you would have on my solution. Thanks!