### PR TITLE
use Socket.gethostname instead of system call for hostname

### DIFF
--- a/lib/jeff.rb
+++ b/lib/jeff.rb
@@ -208,7 +208,7 @@ module Jeff
     # identify the application, its version number, programming language, and
     # host.
     def default_user_agent
-      "Jeff/#{VERSION} (Language=Ruby; #{`hostname`.chomp})"
+      "Jeff/#{VERSION} (Language=Ruby; #{Socket.gethostname})"
     end
   end
 end


### PR DESCRIPTION
This improves compatibility when running on environments that don't allow system calls, or don't respond to `hostname`. In my case, I am running on AWS Lambda, which does not respond to the `hostname` call, causing the error:
```
Errno::ENOENT: No such file or directory - hostname
```

This change fixes the problem for me, and I see no downside. 