### PR TITLE
Add configurable request timeout options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.3 12/12/2021
+
+- Add configurable options for request timeout
+
 # 1.3.0 15/4/2015
 
 - Handle overly long request queries

--- a/lib/jeff/version.rb
+++ b/lib/jeff/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Jeff
-  VERSION = '2.0.2'
+  VERSION = '2.0.3'
 end

--- a/test/test_jeff.rb
+++ b/test/test_jeff.rb
@@ -171,4 +171,15 @@ class TestJeffInAction < Minitest::Test
     @client.proxy = 'http://my.proxy:4321'
     assert @client.connection.proxy
   end
+
+  def test_default_timeout_options
+    assert_equal Jeff::DEFAULT_CONNECT_TIMEOUT, @client.connection.connection[:connect_timeout]
+    assert_equal Jeff::DEFAULT_READ_TIMEOUT, @client.connection.connection[:read_timeout]
+  end
+
+  def test_custom_timeout_options
+    @client.connection(connect_timeout: 2, read_timeout: 25)
+    assert_equal 2, @client.connection.connection[:connect_timeout]
+    assert_equal 25, @client.connection.connection[:read_timeout]
+  end
 end


### PR DESCRIPTION
I would like to be able to adjust the timeout time so that it can be dynamically changed if there is a large delay or host latency.

@hakanensari, check please